### PR TITLE
Version number adjusted

### DIFF
--- a/ExportIt.manifest
+++ b/ExportIt.manifest
@@ -4,7 +4,7 @@
     "id": "4dcff078-d99d-4918-809e-1dfb912d2c44",
     "author": "Wilko Vehreke",
     "description": "Export a design or parts of a design into several formats",
-    "version": "0.7.1",
+    "version": "0.8.1",
     "runOnStartup": false,
     "supportedOS": "windows|mac",
     "editEnabled": true

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Version | Date | Description
 0.6.0 | 15.08.2020 | Some artists use top-level components to group bodies or sub-components by color or material. These groups are then also used for the final STL export. The new STL option _One File Top Level Occurrence_ complies with these exports. Documentation slightly enhanced.
 0.7.0 | 31.08.2020 | _Custom_ STL refinements added in case the predefined refinements _Low_, _Medium_, _High_ and _Ultra_ do not match the use case. _Exclude Components_ filter added to the _Export Options_. In contrast to the selection filter _Export Bodies_, this filter is saved in the project configuration and used for every export of the design. Useful for imported subassemblies that don't maintain the link (broken) anymore. This closes the enhancement #13. Referenced sub-assemblies are now handled correctly, if "Exclude Links" is activated. This fixes issue #12. Framework configuration config.py renamed to avoid conflicts with other add-ins that are using the [apper framework](https://github.com/tapnair/apper). This fixes #14.
 0.7.1 | 03.09.2020 | 0.7.0 did not correctly raise the version flag and therefore did not initialize the new functions
-0.8.0 | 20.10.2020 | fixes #21, documentation and summary report enhancement based on #20 added. Empty components removed from components filter based on #20. API behavior changed with Fusion 360 (2.0.9142) and this change makes it compatible with the new behavior and closes #24
+0.8.1 | 20.10.2020 | fixes #21, documentation and summary report enhancement based on #20 added. Empty components removed from components filter based on #20. API behavior changed with Fusion 360 (2.0.9142) and this change makes it compatible with the new behavior and closes #24
 
 ## Known Issus
 

--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -1,5 +1,5 @@
 """ExportIt - Export a design or parts of a design into several formats"""
 
-__version__ = '0.7.1'
+__version__ = '0.8.1'
 __author__ = 'Wilko Vehreke <lichtzeichenanlage@googlemail.com>'
 __all__ = []


### PR DESCRIPTION
0.8.1 adds:

0.8.1 fixes: 
- #24: After Fusion 360 update (2.0.9142) ExportIt claims that no active document is available
- #21: Crash starting ExportIt 

0.8.1 closes: 
- #20: F3d file not created 